### PR TITLE
add missing logger initialization converter

### DIFF
--- a/lib/logstash/inputs/eventlog.rb
+++ b/lib/logstash/inputs/eventlog.rb
@@ -54,6 +54,7 @@ class LogStash::Inputs::EventLog < LogStash::Inputs::Base
       raise
     end
     @converter = LogStash::Util::Charset.new(Encoding.find(@charset))
+    @converter.logger = @logger
   end # def register
 
   public


### PR DESCRIPTION
add missing logger initialization 

[2020-12-29T19:35:04,647][ERROR][logstash.javapipeline    ][main][d1139d77b05e35c4e8c8e4855f8788cabd33988258b9baf80249694728ea06f9] A plugin had an unrecoverable error. Will restart this plugin.
  Pipeline_id:main
  Plugin: <LogStash::Inputs::EventLog charset=>"locale", interval=>60000, id=>"d1139d77b05e35c4e8c8e4855f8788cabd33988258b9baf80249694728ea06f9", type=>"security-eventlog", logfile=>"Security", enable_metric=>true, codec=><LogStash::Codecs::Plain id=>"plain_925a6076-4076-4cb9-8c6f-f821c142b491", enable_metric=>true, charset=>"UTF-8">>
  Error: private method `warn' called for nil:NilClass
  Exception: NoMethodError
  Stack: C:/logstash-eventlog/logstash-7.10.1/logstash-core/lib/logstash/util/charset.rb:43:in `block in convert'
org/jruby/RubyKernel.java:1897:in `tap'
C:/logstash-eventlog/logstash-7.10.1/logstash-core/lib/logstash/util/charset.rb:42:in `convert'
C:/logstash-eventlog/logstash-7.10.1/vendor/bundle/jruby/2.5.0/gems/logstash-input-eventlog-4.1.3/lib/logstash/inputs/eventlog.rb:110:in `convert'
C:/logstash-eventlog/logstash-7.10.1/vendor/bundle/jruby/2.5.0/gems/logstash-input-eventlog-4.1.3/lib/logstash/inputs/eventlog.rb:102:in `block in process'
org/jruby/RubyHash.java:1415:in `each'
C:/logstash-eventlog/logstash-7.10.1/vendor/bundle/jruby/2.5.0/gems/logstash-input-eventlog-4.1.3/lib/logstash/inputs/eventlog.rb:100:in `process'
C:/logstash-eventlog/logstash-7.10.1/vendor/bundle/jruby/2.5.0/gems/logstash-input-eventlog-4.1.3/lib/logstash/inputs/eventlog.rb:72:in `block in run'
org/jruby/RubyArray.java:1809:in `each'
C:/logstash-eventlog/logstash-7.10.1/vendor/bundle/jruby/2.5.0/gems/logstash-input-eventlog-4.1.3/lib/logstash/inputs/eventlog.rb:72:in `run'
C:/logstash-eventlog/logstash-7.10.1/logstash-core/lib/logstash/java_pipeline.rb:405:in `inputworker'
C:/logstash-eventlog/logstash-7.10.1/logstash-core/lib/logstash/java_pipeline.rb:396:in `block in start_input'

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
